### PR TITLE
app-emulation/wine-any: Added alternative source.

### DIFF
--- a/app-emulation/wine-any/wine-any-9999.ebuild
+++ b/app-emulation/wine-any/wine-any-9999.ebuild
@@ -12,7 +12,7 @@ MY_PN="${PN%%-*}"
 MY_P="${MY_PN}-${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
+	EGIT_REPO_URI="https://source.winehq.org/git/wine.git https://github.com/wine-mirror/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
 	SRC_URI=""


### PR DESCRIPTION
Signed-off-by: Jacob Hrbek <werifgx@gmail.com>

Fixes: https://bugs.gentoo.org/673974

Package-Manager: Portage-2.3.52, Repoman-2.3.12