### PR TITLE
app-emulation/wine-any: Added alternative source.

### DIFF
--- a/app-emulation/wine-any/wine-any-9999.ebuild
+++ b/app-emulation/wine-any/wine-any-9999.ebuild
@@ -12,7 +12,7 @@ MY_PN="${PN%%-*}"
 MY_P="${MY_PN}-${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
+	EGIT_REPO_URI="https://source.winehq.org/git/wine.git https://github.com/wine-mirror/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
 	SRC_URI=""

--- a/app-emulation/wine-d3d9/wine-d3d9-9999.ebuild
+++ b/app-emulation/wine-d3d9/wine-d3d9-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ MY_PN="${PN%%-*}"
 MY_P="${MY_PN}-${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
+	EGIT_REPO_URI="https://source.winehq.org/git/wine.git https://github.com/wine-mirror/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
 	SRC_URI=""

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ MY_PN="${PN%%-*}"
 MY_P="${MY_PN}-${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
+	EGIT_REPO_URI="https://source.winehq.org/git/wine.git https://github.com/wine-mirror/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
 	SRC_URI=""

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ MY_PN="${PN%%-*}"
 MY_P="${MY_PN}-${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
+	EGIT_REPO_URI="https://source.winehq.org/git/wine.git https://github.com/wine-mirror/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
 	SRC_URI=""


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/673974
Signed-off-by: Jacob Hrbek werifgx@gmail.com
Package-Manager: Portage-2.3.52, Repoman-2.3.12