### PR TITLE
app-emulation/wine: Update pkg_pretend to allow bin installs

### DIFF
--- a/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
@@ -7,11 +7,11 @@ PLOCALES="ar ast bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko 
 PLOCALE_BACKUP="en"
 
 inherit autotools eapi7-ver estack eutils flag-o-matic gnome2-utils l10n multilib multilib-minimal pax-utils toolchain-funcs virtualx xdg-utils
-
 MY_PN="${PN%%-*}"
-MY_P="${MY_PN}-${PV}"
+MY_PV="${PV/_/-}"
+MY_P="${MY_PN}-${MY_PV}"
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
@@ -19,12 +19,16 @@ if [[ ${PV} == "9999" ]] ; then
 	#KEYWORDS=""
 else
 	MAJOR_V=$(ver_cut 1)
-	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.x/${MY_P}.tar.xz"
+	MINOR_V=$(ver_cut 2)
+    if [[ ${MINOR_V} != "0" ]] ; then
+        MINOR_V="x"
+    fi
+	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
 S="${WORKDIR}/${MY_P}"
 
-STAGING_P="wine-staging-${PV}"
+STAGING_P="wine-staging-${MY_PV}"
 STAGING_DIR="${WORKDIR}/${STAGING_P}"
 GWP_V="20200523"
 PATCHDIR="${WORKDIR}/gentoo-wine-patches"
@@ -35,15 +39,15 @@ SRC_URI="${SRC_URI}
 	https://dev.gentoo.org/~sarnex/distfiles/wine/gentoo-wine-patches-${GWP_V}.tar.xz
 "
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	STAGING_EGIT_REPO_URI="https://github.com/wine-staging/wine-staging.git"
 else
 	SRC_URI="${SRC_URI}
-	staging? ( https://github.com/wine-staging/wine-staging/archive/v${PV}.tar.gz -> ${STAGING_P}.tar.gz )"
+	staging? ( https://github.com/wine-staging/wine-staging/archive/v${MY_PV}.tar.gz -> ${STAGING_P}.tar.gz )"
 fi
 
 LICENSE="LGPL-2.1"
-SLOT="${PV}"
+SLOT="${MY_PV}"
 IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos elibc_glibc +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos kernel_FreeBSD +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png prelink pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
@@ -171,7 +175,7 @@ PATCHES=(
 PATCHES_BIN=()
 
 # https://bugs.gentoo.org/show_bug.cgi?id=635222
-if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${PV} == 9999 ]]; then
+if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${MY_PV} == 9999 ]]; then
 	DEPEND+=" dev-util/patchbin"
 fi
 
@@ -285,44 +289,46 @@ wine_env_vcs_vars() {
 }
 
 pkg_pretend() {
-	wine_build_environment_check || die
+	if [[ ${MERGE_TYPE} != binary ]] ; then
+		wine_build_environment_check || die
 
-	# Verify OSS support
-	if use oss && ! use kernel_FreeBSD; then
-		if ! has_version ">=media-sound/oss-4"; then
-			eerror "You cannot build wine with USE=oss without having support from a"
-			eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
-			eerror
-			die
+		# Verify OSS support
+		if use oss && ! use kernel_FreeBSD; then
+			if ! has_version ">=media-sound/oss-4"; then
+				eerror "You cannot build wine with USE=oss without having support from a"
+				eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
+				eerror
+				die
+			fi
 		fi
-	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
+		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target i686-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target x86_64-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 	fi
 }
 
@@ -330,7 +336,7 @@ pkg_setup() {
 	wine_build_environment_check || die
 	wine_env_vcs_vars || die
 
-	WINE_VARIANT="${PN#wine}-${PV}"
+	WINE_VARIANT="${PN#wine}-${MY_PV}"
 	WINE_VARIANT="${WINE_VARIANT#-}"
 
 	MY_PREFIX="${EPREFIX}/usr/lib/wine-${WINE_VARIANT}"
@@ -344,7 +350,7 @@ pkg_setup() {
 }
 
 src_unpack() {
-	if [[ ${PV} == "9999" ]] ; then
+	if [[ ${MY_PV} == "9999" ]] ; then
 		EGIT_CHECKOUT_DIR="${S}" git-r3_src_unpack
 		if use staging; then
 			local CURRENT_WINE_COMMIT=${EGIT_VERSION}
@@ -614,12 +620,12 @@ multilib_src_install_all() {
 }
 
 pkg_postinst() {
-	eselect wine register ${P}
+	eselect wine register ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine register --vanilla ${P} || die
+		eselect wine register --vanilla ${PN}-${MY_PV} || die
 	else
 		if use staging; then
-			eselect wine register --staging ${P} || die
+			eselect wine register --staging ${PN}-${MY_PV} || die
 		fi
 	fi
 
@@ -642,12 +648,12 @@ pkg_postinst() {
 }
 
 pkg_prerm() {
-	eselect wine deregister ${P}
+	eselect wine deregister ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine deregister --vanilla ${P} || die
+		eselect wine deregister --vanilla ${PN}-${MY_PV} || die
 	else
 		if use staging; then
-			eselect wine deregister --staging ${P} || die
+			eselect wine deregister --staging  ${PN}-${MY_PV}|| die
 		fi
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -7,11 +7,11 @@ PLOCALES="ar ast bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko 
 PLOCALE_BACKUP="en"
 
 inherit autotools eapi7-ver estack eutils flag-o-matic gnome2-utils l10n multilib multilib-minimal pax-utils toolchain-funcs virtualx xdg-utils
-
 MY_PN="${PN%%-*}"
-MY_P="${MY_PN}-${PV}"
+MY_PV="${PV/_/-}"
+MY_P="${MY_PN}-${MY_PV}"
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
@@ -19,12 +19,16 @@ if [[ ${PV} == "9999" ]] ; then
 	#KEYWORDS=""
 else
 	MAJOR_V=$(ver_cut 1)
-	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.x/${MY_P}.tar.xz"
+	MINOR_V=$(ver_cut 2)
+    if [[ ${MINOR_V} != "0" ]] ; then
+        MINOR_V="x"
+    fi
+	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
 S="${WORKDIR}/${MY_P}"
 
-STAGING_P="wine-staging-${PV}"
+STAGING_P="wine-staging-${MY_PV}"
 STAGING_DIR="${WORKDIR}/${STAGING_P}"
 GWP_V="20200523"
 PATCHDIR="${WORKDIR}/gentoo-wine-patches"
@@ -35,15 +39,15 @@ SRC_URI="${SRC_URI}
 	https://dev.gentoo.org/~sarnex/distfiles/wine/gentoo-wine-patches-${GWP_V}.tar.xz
 "
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	STAGING_EGIT_REPO_URI="https://github.com/wine-staging/wine-staging.git"
 else
 	SRC_URI="${SRC_URI}
-	staging? ( https://github.com/wine-staging/wine-staging/archive/v${PV}.tar.gz -> ${STAGING_P}.tar.gz )"
+	staging? ( https://github.com/wine-staging/wine-staging/archive/v${MY_PV}.tar.gz -> ${STAGING_P}.tar.gz )"
 fi
 
 LICENSE="LGPL-2.1"
-SLOT="${PV}"
+SLOT="${MY_PV}"
 IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos elibc_glibc +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos kernel_FreeBSD +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png prelink pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
@@ -171,7 +175,7 @@ PATCHES=(
 PATCHES_BIN=()
 
 # https://bugs.gentoo.org/show_bug.cgi?id=635222
-if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${PV} == 9999 ]]; then
+if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${MY_PV} == 9999 ]]; then
 	DEPEND+=" dev-util/patchbin"
 fi
 
@@ -285,44 +289,46 @@ wine_env_vcs_vars() {
 }
 
 pkg_pretend() {
-	wine_build_environment_check || die
+	if [[ ${MERGE_TYPE} != binary ]] ; then
+		wine_build_environment_check || die
 
-	# Verify OSS support
-	if use oss && ! use kernel_FreeBSD; then
-		if ! has_version ">=media-sound/oss-4"; then
-			eerror "You cannot build wine with USE=oss without having support from a"
-			eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
-			eerror
-			die
+		# Verify OSS support
+		if use oss && ! use kernel_FreeBSD; then
+			if ! has_version ">=media-sound/oss-4"; then
+				eerror "You cannot build wine with USE=oss without having support from a"
+				eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
+				eerror
+				die
+			fi
 		fi
-	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
+		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target i686-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target x86_64-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 	fi
 }
 
@@ -330,7 +336,7 @@ pkg_setup() {
 	wine_build_environment_check || die
 	wine_env_vcs_vars || die
 
-	WINE_VARIANT="${PN#wine}-${PV}"
+	WINE_VARIANT="${PN#wine}-${MY_PV}"
 	WINE_VARIANT="${WINE_VARIANT#-}"
 
 	MY_PREFIX="${EPREFIX}/usr/lib/wine-${WINE_VARIANT}"
@@ -344,7 +350,7 @@ pkg_setup() {
 }
 
 src_unpack() {
-	if [[ ${PV} == "9999" ]] ; then
+	if [[ ${MY_PV} == "9999" ]] ; then
 		EGIT_CHECKOUT_DIR="${S}" git-r3_src_unpack
 		if use staging; then
 			local CURRENT_WINE_COMMIT=${EGIT_VERSION}
@@ -522,9 +528,10 @@ multilib_src_configure() {
 		$(use_with vaapi va)
 	)
 
-	local PKG_CONFIG
+	local PKG_CONFIG AR RANLIB
 	# Avoid crossdev's i686-pc-linux-gnu-pkg-config if building wine32 on amd64; #472038
-	tc-export PKG_CONFIG
+	# set AR and RANLIB to make QA scripts happy; #483342
+	tc-export PKG_CONFIG AR RANLIB
 
 	if use amd64; then
 		if [[ ${ABI} == amd64 ]]; then
@@ -613,12 +620,12 @@ multilib_src_install_all() {
 }
 
 pkg_postinst() {
-	eselect wine register ${P}
+	eselect wine register ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine register --vanilla ${P} || die
+		eselect wine register --vanilla ${PN}-${MY_PV} || die
 	else
 		if use staging; then
-			eselect wine register --staging ${P} || die
+			eselect wine register --staging ${PN}-${MY_PV} || die
 		fi
 	fi
 
@@ -641,12 +648,12 @@ pkg_postinst() {
 }
 
 pkg_prerm() {
-	eselect wine deregister ${P}
+	eselect wine deregister ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine deregister --vanilla ${P} || die
+		eselect wine deregister --vanilla ${PN}-${MY_PV} || die
 	else
 		if use staging; then
-			eselect wine deregister --staging ${P} || die
+			eselect wine deregister --staging  ${PN}-${MY_PV}|| die
 		fi
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
@@ -7,11 +7,11 @@ PLOCALES="ar ast bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko 
 PLOCALE_BACKUP="en"
 
 inherit autotools eapi7-ver estack eutils flag-o-matic gnome2-utils l10n multilib multilib-minimal pax-utils toolchain-funcs virtualx xdg-utils
-
 MY_PN="${PN%%-*}"
-MY_P="${MY_PN}-${PV}"
+MY_PV="${PV/_/-}"
+MY_P="${MY_PN}-${MY_PV}"
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
@@ -19,7 +19,11 @@ if [[ ${PV} == "9999" ]] ; then
 	#KEYWORDS=""
 else
 	MAJOR_V=$(ver_cut 1)
-	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.x/${MY_P}.tar.xz"
+	MINOR_V=$(ver_cut 2)
+    if [[ ${MINOR_V} != "0" ]] ; then
+        MINOR_V="x"
+    fi
+	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
 S="${WORKDIR}/${MY_P}"
@@ -69,7 +73,7 @@ COMMON_DEPEND="
 		media-plugins/gst-plugins-meta:1.0[${MULTILIB_USEDEP}]
 	)
 	jpeg? ( virtual/jpeg:0=[${MULTILIB_USEDEP}] )
-	kerberos? ( virtual/krb5[${MULTILIB_USEDEP}] )
+	kerberos? ( virtual/krb5:0=[${MULTILIB_USEDEP}] )
 	lcms? ( media-libs/lcms:2=[${MULTILIB_USEDEP}] )
 	ldap? ( net-nds/openldap:=[${MULTILIB_USEDEP}] )
 	mp3? ( >=media-sound/mpg123-1.5.0[${MULTILIB_USEDEP}] )
@@ -147,7 +151,7 @@ PATCHES=(
 PATCHES_BIN=()
 
 # https://bugs.gentoo.org/show_bug.cgi?id=635222
-if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${PV} == 9999 ]]; then
+if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${MY_PV} == 9999 ]]; then
 	DEPEND+=" dev-util/patchbin"
 fi
 
@@ -241,52 +245,54 @@ wine_env_vcs_vars() {
 	local pn_live_val="${pn_live_var}"
 	eval pn_live_val='$'${pn_live_val}
 	if [[ ! -z ${EGIT_COMMIT} ]]; then
-		eerror "Commits must now be specified using the environmental variables"
-		eerror "EGIT_OVERRIDE_COMMIT_WINE"
+		eerror "Commits must now be specified using the environment variables:"
+		eerror "  EGIT_OVERRIDE_COMMIT_WINE"
 		eerror
 		return 1
 	fi
 }
 
 pkg_pretend() {
-	wine_build_environment_check || die
+	if [[ ${MERGE_TYPE} != binary ]] ; then
+		wine_build_environment_check || die
 
-	# Verify OSS support
-	if use oss && ! use kernel_FreeBSD; then
-		if ! has_version ">=media-sound/oss-4"; then
-			eerror "You cannot build wine with USE=oss without having support from a"
-			eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
-			eerror
-			die
+		# Verify OSS support
+		if use oss && ! use kernel_FreeBSD; then
+			if ! has_version ">=media-sound/oss-4"; then
+				eerror "You cannot build wine with USE=oss without having support from a"
+				eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
+				eerror
+				die
+			fi
 		fi
-	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
+		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target i686-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target x86_64-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 	fi
 }
 
@@ -294,7 +300,7 @@ pkg_setup() {
 	wine_build_environment_check || die
 	wine_env_vcs_vars || die
 
-	WINE_VARIANT="${PN#wine}-${PV}"
+	WINE_VARIANT="${PN#wine}-${MY_PV}"
 	WINE_VARIANT="${WINE_VARIANT#-}"
 
 	MY_PREFIX="${EPREFIX}/usr/lib/wine-${WINE_VARIANT}"
@@ -308,7 +314,7 @@ pkg_setup() {
 }
 
 src_unpack() {
-	if [[ ${PV} == "9999" ]] ; then
+	if [[ ${MY_PV} == "9999" ]] ; then
 		EGIT_CHECKOUT_DIR="${S}" git-r3_src_unpack
 	fi
 
@@ -449,9 +455,10 @@ multilib_src_configure() {
 		$(use_with xml xslt)
 	)
 
-	local PKG_CONFIG
+	local PKG_CONFIG AR RANLIB
 	# Avoid crossdev's i686-pc-linux-gnu-pkg-config if building wine32 on amd64; #472038
-	tc-export PKG_CONFIG
+	# set AR and RANLIB to make QA scripts happy; #483342
+	tc-export PKG_CONFIG AR RANLIB
 
 	if use amd64; then
 		if [[ ${ABI} == amd64 ]]; then
@@ -540,9 +547,9 @@ multilib_src_install_all() {
 }
 
 pkg_postinst() {
-	eselect wine register ${P}
+	eselect wine register ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine register --vanilla ${P} || die
+		eselect wine register --vanilla ${PN}-${MY_PV} || die
 	fi
 
 	eselect wine update --all --if-unset || die
@@ -564,9 +571,9 @@ pkg_postinst() {
 }
 
 pkg_prerm() {
-	eselect wine deregister ${P}
+	eselect wine deregister ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine deregister --vanilla ${P} || die
+		eselect wine deregister --vanilla ${PN}-${MY_PV} || die
 	fi
 
 	eselect wine update --all --if-unset || die

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -7,11 +7,11 @@ PLOCALES="ar ast bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko 
 PLOCALE_BACKUP="en"
 
 inherit autotools eapi7-ver estack eutils flag-o-matic gnome2-utils l10n multilib multilib-minimal pax-utils toolchain-funcs virtualx xdg-utils
-
 MY_PN="${PN%%-*}"
-MY_P="${MY_PN}-${PV}"
+MY_PV="${PV/_/-}"
+MY_P="${MY_PN}-${MY_PV}"
 
-if [[ ${PV} == "9999" ]] ; then
+if [[ ${MY_PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://source.winehq.org/git/wine.git"
 	EGIT_BRANCH="master"
 	inherit git-r3
@@ -19,7 +19,11 @@ if [[ ${PV} == "9999" ]] ; then
 	#KEYWORDS=""
 else
 	MAJOR_V=$(ver_cut 1)
-	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.x/${MY_P}.tar.xz"
+	MINOR_V=$(ver_cut 2)
+    if [[ ${MINOR_V} != "0" ]] ; then
+        MINOR_V="x"
+    fi
+	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
 S="${WORKDIR}/${MY_P}"
@@ -69,7 +73,7 @@ COMMON_DEPEND="
 		media-plugins/gst-plugins-meta:1.0[${MULTILIB_USEDEP}]
 	)
 	jpeg? ( virtual/jpeg:0=[${MULTILIB_USEDEP}] )
-	kerberos? ( virtual/krb5[${MULTILIB_USEDEP}] )
+	kerberos? ( virtual/krb5:0=[${MULTILIB_USEDEP}] )
 	lcms? ( media-libs/lcms:2=[${MULTILIB_USEDEP}] )
 	ldap? ( net-nds/openldap:=[${MULTILIB_USEDEP}] )
 	mp3? ( >=media-sound/mpg123-1.5.0[${MULTILIB_USEDEP}] )
@@ -147,7 +151,7 @@ PATCHES=(
 PATCHES_BIN=()
 
 # https://bugs.gentoo.org/show_bug.cgi?id=635222
-if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${PV} == 9999 ]]; then
+if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${MY_PV} == 9999 ]]; then
 	DEPEND+=" dev-util/patchbin"
 fi
 
@@ -241,52 +245,54 @@ wine_env_vcs_vars() {
 	local pn_live_val="${pn_live_var}"
 	eval pn_live_val='$'${pn_live_val}
 	if [[ ! -z ${EGIT_COMMIT} ]]; then
-		eerror "Commits must now be specified using the environmental variables"
-		eerror "EGIT_OVERRIDE_COMMIT_WINE"
+		eerror "Commits must now be specified using the environment variables:"
+		eerror "  EGIT_OVERRIDE_COMMIT_WINE"
 		eerror
 		return 1
 	fi
 }
 
 pkg_pretend() {
-	wine_build_environment_check || die
+	if [[ ${MERGE_TYPE} != binary ]] ; then
+		wine_build_environment_check || die
 
-	# Verify OSS support
-	if use oss && ! use kernel_FreeBSD; then
-		if ! has_version ">=media-sound/oss-4"; then
-			eerror "You cannot build wine with USE=oss without having support from a"
-			eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
-			eerror
-			die
+		# Verify OSS support
+		if use oss && ! use kernel_FreeBSD; then
+			if ! has_version ">=media-sound/oss-4"; then
+				eerror "You cannot build wine with USE=oss without having support from a"
+				eerror "FreeBSD kernel or >=media-sound/oss-4 (only available through external repos)"
+				eerror
+				die
+			fi
 		fi
-	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
+		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target i686-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
+			eerror
+			eerror "USE=\"mingw\" is currently experimental, and requires the"
+			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
+			eerror
+			eerror "These can be installed by using 'sys-devel/crossdev':"
+			eerror
+			eerror "crossdev --target x86_64-w64-mingw32"
+			eerror
+			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
+			eerror
+			die "MinGW build was enabled, but no compiler to support it was found."
+		fi
 	fi
 }
 
@@ -294,7 +300,7 @@ pkg_setup() {
 	wine_build_environment_check || die
 	wine_env_vcs_vars || die
 
-	WINE_VARIANT="${PN#wine}-${PV}"
+	WINE_VARIANT="${PN#wine}-${MY_PV}"
 	WINE_VARIANT="${WINE_VARIANT#-}"
 
 	MY_PREFIX="${EPREFIX}/usr/lib/wine-${WINE_VARIANT}"
@@ -308,7 +314,7 @@ pkg_setup() {
 }
 
 src_unpack() {
-	if [[ ${PV} == "9999" ]] ; then
+	if [[ ${MY_PV} == "9999" ]] ; then
 		EGIT_CHECKOUT_DIR="${S}" git-r3_src_unpack
 	fi
 
@@ -449,9 +455,10 @@ multilib_src_configure() {
 		$(use_with xml xslt)
 	)
 
-	local PKG_CONFIG
+	local PKG_CONFIG AR RANLIB
 	# Avoid crossdev's i686-pc-linux-gnu-pkg-config if building wine32 on amd64; #472038
-	tc-export PKG_CONFIG
+	# set AR and RANLIB to make QA scripts happy; #483342
+	tc-export PKG_CONFIG AR RANLIB
 
 	if use amd64; then
 		if [[ ${ABI} == amd64 ]]; then
@@ -540,9 +547,9 @@ multilib_src_install_all() {
 }
 
 pkg_postinst() {
-	eselect wine register ${P}
+	eselect wine register ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine register --vanilla ${P} || die
+		eselect wine register --vanilla ${PN}-${MY_PV} || die
 	fi
 
 	eselect wine update --all --if-unset || die
@@ -564,9 +571,9 @@ pkg_postinst() {
 }
 
 pkg_prerm() {
-	eselect wine deregister ${P}
+	eselect wine deregister ${PN}-${MY_PV}
 	if [[ ${PN} == "wine-vanilla" ]]; then
-		eselect wine deregister --vanilla ${P} || die
+		eselect wine deregister --vanilla ${PN}-${MY_PV} || die
 	fi
 
 	eselect wine update --all --if-unset || die


### PR DESCRIPTION
These are building from source checks and aren't neccessary when
installing from a bin package

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>