### PR TITLE
app-emulation/wine-{staging,vanilla}: drop deprecated ltprune eclass 

### DIFF
--- a/app-emulation/wine-staging/wine-staging-4.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.0.ebuild
@@ -533,7 +533,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.1.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.10.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.10.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.11.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.12.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.12.1.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.13.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.14.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.14.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.15.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.15.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.16.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.16.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.17.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.17.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.18.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.18.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.19.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.19.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.2.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.20.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.20.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.21.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.21.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.3.ebuild
@@ -534,7 +534,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.4-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.4-r1.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.4.ebuild
@@ -534,7 +534,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.5.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.6-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.6-r1.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.6.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.7-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.7-r1.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.7.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.8.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-4.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-4.9.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.0.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.1.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.10-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.10-r1.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.11.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.12.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.13.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.14.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.14.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.15.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.15.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.16.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.16.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.17.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.17.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.18.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.18.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.19.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.19.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.2.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.20.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.20.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.21.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.21.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
@@ -565,7 +565,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
@@ -566,7 +566,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.22.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.3-r1.ebuild
@@ -534,7 +534,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.3.ebuild
@@ -532,7 +532,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.4.ebuild
@@ -534,7 +534,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.5-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.5-r1.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.5.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.6.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.7.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.8.ebuild
@@ -535,7 +535,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-5.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.9.ebuild
@@ -536,7 +536,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.0.ebuild
@@ -574,7 +574,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.1.ebuild
@@ -574,7 +574,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.10.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.10.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.11.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.12.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.13.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.2.ebuild
@@ -573,7 +573,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
@@ -575,7 +575,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3.ebuild
@@ -574,7 +574,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.4.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.5.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.6.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.7.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.8.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-6.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.9.ebuild
@@ -572,7 +572,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -571,7 +571,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.0.1.ebuild
@@ -459,7 +459,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.0.2.ebuild
@@ -459,7 +459,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.0.ebuild
@@ -459,7 +459,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.1.ebuild
@@ -458,7 +458,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.10.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.11.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.12.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.12.1.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.13.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.14.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.14.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.15.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.15.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.16.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.16.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.17.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.17.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.18.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.18.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.19.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.19.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.2.ebuild
@@ -458,7 +458,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.20.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.20.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.21.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.21.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.3.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.4.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.5.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.6-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.6-r1.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.6.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.7-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.7-r1.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.7.ebuild
@@ -460,7 +460,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.8.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-4.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-4.9.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.0.1.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.0.2.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.0.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.0.3-r1.ebuild
@@ -463,7 +463,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.0.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.0.3.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.0.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.1.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.10.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.11.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.12.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.12.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.13.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.14.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.14.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.15.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.15.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.16.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.16.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.17.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.17.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.18.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.18.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.19.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.19.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.2.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.20.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.20.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.21.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.21.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
@@ -491,7 +491,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.3.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.4.ebuild
@@ -461,7 +461,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.5.ebuild
@@ -463,7 +463,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.6.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.7.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.8.ebuild
@@ -462,7 +462,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-5.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.9.ebuild
@@ -463,7 +463,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
@@ -493,7 +493,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
@@ -493,7 +493,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
@@ -494,7 +494,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
@@ -493,7 +493,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
@@ -493,7 +493,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
@@ -494,7 +494,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
@@ -495,7 +495,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
@@ -494,7 +494,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	l10n_for_each_locale_do add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -492,7 +492,7 @@ multilib_src_install_all() {
 	plocale_for_each_locale add_locale_docs
 
 	einstalldocs
-	prune_libtool_files --all
+	find "${ED}" -name *.la -delete || die
 
 	if ! use perl ; then # winedump calls function_grep.pl, and winemaker is a perl script
 		rm "${D%/}${MY_PREFIX}"/bin/{wine{dump,maker},function_grep.pl} \


### PR DESCRIPTION
app-emulation/wine-{staging,vanilla}: drop deprecated ltprune eclass

Time to drop all ltprune stuff. This are the last packages in tree, all other have been already migrated. No need for a revbump.