### PR TITLE
app-emulation/wine-{vanilla,staging}: support building with mingw64-toolchain + some fixes

### DIFF
--- a/app-emulation/wine-staging/files/wine-staging-5.22-gcc11-sincos.patch
+++ b/app-emulation/wine-staging/files/wine-staging-5.22-gcc11-sincos.patch
@@ -1,0 +1,87 @@
+https://bugs.gentoo.org/787665
+
+https://source.winehq.org/git/wine.git/commit/f0131276
+From: Jacek Caban <jacek@codeweavers.com>
+Date: Tue, 18 May 2021 18:08:43 +0200
+Subject: [PATCH] msvcrt: Add sincos to importlib.
+
+Fixes cross compilation with GCC 11, which may optimize a pair of sin(),
+cos() calls to a single sincos() call, which is not exported by any
+msvcrt version.
+--- a/dlls/msvcr100/Makefile.in
++++ b/dlls/msvcr100/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr110/Makefile.in
++++ b/dlls/msvcr110/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr120/Makefile.in
++++ b/dlls/msvcr120/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr70/Makefile.in
++++ b/dlls/msvcr70/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr71/Makefile.in
++++ b/dlls/msvcr71/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr80/Makefile.in
++++ b/dlls/msvcr80/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr90/Makefile.in
++++ b/dlls/msvcr90/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcrt/Makefile.in
++++ b/dlls/msvcrt/Makefile.in
+@@ -40,2 +40,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcrt/sincos.c
++++ b/dlls/msvcrt/sincos.c
+@@ -0,0 +1,20 @@
++#if 0
++#pragma makedep implib
++#endif
++
++#include <math.h>
++
++/* GCC may optimize a pair of sin(), cos() calls to a single sincos() call,
++ * which is not exported by any msvcrt version. */
++
++void sincos(double x, double *s, double *c)
++{
++    *s = sin(x);
++    *c = cos(x);
++}
++
++void sincosf(float x, float *s, float *c)
++{
++    *s = sinf(x);
++    *c = cosf(x);
++}
+--- a/dlls/ucrtbase/Makefile.in
++++ b/dlls/ucrtbase/Makefile.in
+@@ -39,2 +39,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \

--- a/app-emulation/wine-staging/files/wine-staging-6.6-glibc2.34-libresolv.patch
+++ b/app-emulation/wine-staging/files/wine-staging-6.6-glibc2.34-libresolv.patch
@@ -1,0 +1,18 @@
+https://bugs.winehq.org/show_bug.cgi?id=51635
+
+https://source.winehq.org/git/wine.git/commit/a3bbf513
+From: Fabian Maurer <dark.shadow4@web.de>
+Date: Thu, 19 Aug 2021 00:53:56 +0200
+Subject: [PATCH] configure: Improve resolv lib test for glibc 2.34.
+
+res_init and res_query don't need lresolv on glibc 2.34.
+Added another test for ns_initparse and friends.
+--- a/configure.ac
++++ b/configure.ac
+@@ -1503,5 +1503,5 @@
+ #include <netinet/in.h>
+ #endif
+-#include <resolv.h>]],[[if (!(_res.options & RES_INIT)) res_init(); res_query("foo",ns_c_in,0,0,0)]])],
++#include <resolv.h>]],[[if (!(_res.options & RES_INIT)) res_init(); res_query("foo",ns_c_in,0,0,0); ns_initparse(0,0,0)]])],
+            [ac_cv_have_resolv=${lib:-"none required"}],[ac_cv_have_resolv="not found"])
+          test "x$ac_cv_have_resolv" = "xnot found" || break

--- a/app-emulation/wine-staging/metadata.xml
+++ b/app-emulation/wine-staging/metadata.xml
@@ -18,6 +18,10 @@ This variant of the Wine packaging includes the Wine-Staging patchset.
 	</longdescription>
 	<use>
 		<flag name="capi">Enable ISDN support via CAPI</flag>
+		<flag name="crossdev-mingw">
+			Use <pkg>sys-devel/crossdev</pkg> for the toolchain rather than
+			<pkg>dev-util/mingw64-toolchain</pkg> (requires manual setting up)
+		</flag>
 		<flag name="custom-cflags">Bypass strip-flags; use at your own peril</flag>
 		<flag name="dos">Pull in <pkg>games-emulation/dosbox</pkg> to run DOS applications</flag>
 		<flag name="faudio">Pull in <pkg>app-emulation/faudio</pkg> to provide XAudio2 functionality</flag>

--- a/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
@@ -44,9 +44,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 ncurses netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 ncurses netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -153,7 +154,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -231,32 +233,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -381,6 +369,11 @@ src_configure() {
 
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
+	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
+		export CROSSCFLAGS="${CFLAGS}"
+	fi
 
 	multilib-minimal_src_configure
 }

--- a/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
@@ -169,6 +169,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r1.ebuild
@@ -372,7 +372,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
@@ -44,9 +44,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -152,7 +153,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -230,32 +232,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -381,6 +369,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
@@ -371,7 +371,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-5.22-r2.ebuild
@@ -168,6 +168,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.0.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.0.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.0.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.1.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.1.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.10.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.10.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.10.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.10.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.10.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.10.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.11.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.11.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.11.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.11.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.12.ebuild
@@ -379,7 +379,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.12.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}/wine-staging-6.12-winegcc-equals-args.patch" #800809
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.12.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -237,32 +239,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -389,6 +377,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.13.ebuild
@@ -379,7 +379,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.13.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}/wine-staging-6.12-winegcc-equals-args.patch" #800809
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.13.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -237,32 +239,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -389,6 +377,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.14.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.14.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.14.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.14.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.14.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.14.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.15.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.15.ebuild
@@ -172,6 +172,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.15.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.15.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.15.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.15.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.16.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.16.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.16.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.16.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.17.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.17.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.17.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.17.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.18.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.18.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.18.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.18.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.19.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.19.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.19.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.19.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.2.ebuild
@@ -47,9 +47,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -156,7 +157,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -235,32 +237,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -387,6 +375,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.2.ebuild
@@ -377,7 +377,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.2.ebuild
@@ -172,6 +172,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.20.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.20.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.20.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.20.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.21.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.21.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.21.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.21.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.22.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.22.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -218,32 +220,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -370,6 +358,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.22.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.22.ebuild
@@ -360,7 +360,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.23.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.23.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -218,32 +220,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -370,6 +358,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.23.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.23.ebuild
@@ -360,7 +360,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${PATCHDIR}/patches/${MY_PN}-6.3-Fix-nine.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
@@ -379,7 +379,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -237,32 +239,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -389,6 +377,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.3.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.4.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.4.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.4.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.5.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.5.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.5.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.5.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.6.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.6.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.6.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.6.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.6.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.7.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.7.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.7.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.7.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.8.ebuild
@@ -174,6 +174,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.8.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.8.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.8.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-6.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.9.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gcrypt +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test themes +threads +truetype udev +udisks +unwind usb v4l vaapi vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -157,7 +158,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -236,32 +238,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -388,6 +376,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-6.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.9.ebuild
@@ -173,6 +173,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-6.9.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.9.ebuild
@@ -378,7 +378,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.0.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -218,32 +220,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -370,6 +358,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.0.ebuild
@@ -360,7 +360,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -218,32 +220,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -370,6 +358,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.1.ebuild
@@ -360,7 +360,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.2.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -140,7 +141,8 @@ DEPEND="${COMMON_DEPEND}
 		dev-lang/perl
 		dev-perl/XML-Simple
 	)
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -218,32 +220,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -370,6 +358,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.2.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.2.ebuild
@@ -360,7 +360,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.3-r1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -63,7 +64,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.3-r1.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.4-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.4-r1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -63,7 +64,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.4-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.4-r1.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.5-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.5-r1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -63,7 +64,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.5-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.5-r1.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.6-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.6-r1.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -63,7 +64,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.6-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.6-r1.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.7.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -63,7 +64,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -219,32 +221,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -371,6 +359,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-7.7.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.7.ebuild
@@ -361,7 +361,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.8.ebuild
@@ -359,7 +359,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-7.8.ebuild
+++ b/app-emulation/wine-staging/wine-staging-7.8.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -62,7 +63,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -217,32 +219,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -369,6 +357,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -359,7 +359,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -48,9 +48,10 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="${MY_PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pipelight pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl staging test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	pipelight? ( staging )
@@ -62,7 +63,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -217,32 +219,18 @@ pkg_pretend() {
 			fi
 		fi
 
-		if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target i686-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
-		fi
-
-		if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-			eerror
-			eerror "USE=\"mingw\" is currently experimental, and requires the"
-			eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-			eerror
-			eerror "These can be installed by using 'sys-devel/crossdev':"
-			eerror
-			eerror "crossdev --target x86_64-w64-mingw32"
-			eerror
-			eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-			eerror
-			die "MinGW build was enabled, but no compiler to support it was found."
+		if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+			local mingw=-w64-mingw32
+			for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+				type -P ${mingw}-gcc && continue
+				eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+				eerror "yourself by installing sys-devel/crossdev then running:"
+				eerror
+				eerror "    crossdev --target ${mingw}"
+				eerror
+				eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+				die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+			done
 		fi
 	fi
 }
@@ -369,6 +357,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/files/wine-vanilla-5.22-gcc11-sincos.patch
+++ b/app-emulation/wine-vanilla/files/wine-vanilla-5.22-gcc11-sincos.patch
@@ -1,0 +1,87 @@
+https://bugs.gentoo.org/787665
+
+https://source.winehq.org/git/wine.git/commit/f0131276
+From: Jacek Caban <jacek@codeweavers.com>
+Date: Tue, 18 May 2021 18:08:43 +0200
+Subject: [PATCH] msvcrt: Add sincos to importlib.
+
+Fixes cross compilation with GCC 11, which may optimize a pair of sin(),
+cos() calls to a single sincos() call, which is not exported by any
+msvcrt version.
+--- a/dlls/msvcr100/Makefile.in
++++ b/dlls/msvcr100/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr110/Makefile.in
++++ b/dlls/msvcr110/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr120/Makefile.in
++++ b/dlls/msvcr120/Makefile.in
+@@ -36,2 +36,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr70/Makefile.in
++++ b/dlls/msvcr70/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr71/Makefile.in
++++ b/dlls/msvcr71/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr80/Makefile.in
++++ b/dlls/msvcr80/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcr90/Makefile.in
++++ b/dlls/msvcr90/Makefile.in
+@@ -35,2 +35,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcrt/Makefile.in
++++ b/dlls/msvcrt/Makefile.in
+@@ -40,2 +40,3 @@
+ 	scheduler.c \
++	sincos.c \
+ 	string.c \
+--- a/dlls/msvcrt/sincos.c
++++ b/dlls/msvcrt/sincos.c
+@@ -0,0 +1,20 @@
++#if 0
++#pragma makedep implib
++#endif
++
++#include <math.h>
++
++/* GCC may optimize a pair of sin(), cos() calls to a single sincos() call,
++ * which is not exported by any msvcrt version. */
++
++void sincos(double x, double *s, double *c)
++{
++    *s = sin(x);
++    *c = cos(x);
++}
++
++void sincosf(float x, float *s, float *c)
++{
++    *s = sinf(x);
++    *c = cosf(x);
++}
+--- a/dlls/ucrtbase/Makefile.in
++++ b/dlls/ucrtbase/Makefile.in
+@@ -39,2 +39,3 @@
+ 	scanf.c \
++	sincos.c \
+ 	string.c \

--- a/app-emulation/wine-vanilla/files/wine-vanilla-6.6-glibc2.34-libresolv.patch
+++ b/app-emulation/wine-vanilla/files/wine-vanilla-6.6-glibc2.34-libresolv.patch
@@ -1,0 +1,18 @@
+https://bugs.winehq.org/show_bug.cgi?id=51635
+
+https://source.winehq.org/git/wine.git/commit/a3bbf513
+From: Fabian Maurer <dark.shadow4@web.de>
+Date: Thu, 19 Aug 2021 00:53:56 +0200
+Subject: [PATCH] configure: Improve resolv lib test for glibc 2.34.
+
+res_init and res_query don't need lresolv on glibc 2.34.
+Added another test for ns_initparse and friends.
+--- a/configure.ac
++++ b/configure.ac
+@@ -1503,5 +1503,5 @@
+ #include <netinet/in.h>
+ #endif
+-#include <resolv.h>]],[[if (!(_res.options & RES_INIT)) res_init(); res_query("foo",ns_c_in,0,0,0)]])],
++#include <resolv.h>]],[[if (!(_res.options & RES_INIT)) res_init(); res_query("foo",ns_c_in,0,0,0); ns_initparse(0,0,0)]])],
+            [ac_cv_have_resolv=${lib:-"none required"}],[ac_cv_have_resolv="not found"])
+          test "x$ac_cv_have_resolv" = "xnot found" || break

--- a/app-emulation/wine-vanilla/metadata.xml
+++ b/app-emulation/wine-vanilla/metadata.xml
@@ -18,6 +18,10 @@ This variant of the Wine packaging does not include external patchsets
 	</longdescription>
 	<use>
 		<flag name="capi">Enable ISDN support via CAPI</flag>
+		<flag name="crossdev-mingw">
+			Use <pkg>sys-devel/crossdev</pkg> for the toolchain rather than
+			<pkg>dev-util/mingw64-toolchain</pkg> (requires manual setting up)
+		</flag>
 		<flag name="custom-cflags">Bypass strip-flags; use at your own peril</flag>
 		<flag name="dos">Pull in <pkg>games-emulation/dosbox</pkg> to run DOS applications</flag>
 		<flag name="faudio">Pull in <pkg>app-emulation/faudio</pkg> to provide XAudio2 functionality</flag>

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 ncurses netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 ncurses netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,11 @@ src_configure() {
 
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
+	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
+		export CROSSCFLAGS="${CFLAGS}"
+	fi
 
 	multilib-minimal_src_configure
 }

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r1.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-5.22-r2.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
@@ -34,9 +34,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.1.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.2.ebuild
@@ -34,9 +34,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.2.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
@@ -34,9 +34,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.0.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.1.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.10.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.11.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}/wine-vanilla-6.12-winegcc-equals-args.patch" #800809
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -196,32 +198,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -317,6 +305,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.12.ebuild
@@ -307,7 +307,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}/wine-vanilla-6.12-winegcc-equals-args.patch" #800809
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -196,32 +198,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -317,6 +305,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.13.ebuild
@@ -307,7 +307,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.14.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.15.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.16.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.16.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.16.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.16.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.17.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.17.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.17.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.17.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.18.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.18.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.18.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.18.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.19.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.19.ebuild
@@ -305,7 +305,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.19.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.19.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -128,7 +129,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -194,32 +196,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -315,6 +303,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.2.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.20.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.20.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.20.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.20.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.21.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.21.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.21.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.21.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.22.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.22.ebuild
@@ -297,7 +297,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.22.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.22.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -186,32 +188,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -307,6 +295,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.23.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.23.ebuild
@@ -297,7 +297,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.23.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.23.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -186,32 +188,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -307,6 +295,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -196,32 +198,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -317,6 +305,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${PATCHDIR}/patches/${MY_PN}-6.3-Fix-nine.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3-r1.ebuild
@@ -307,7 +307,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.3.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.5.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.6.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.7.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.8.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${FILESDIR}"/${PN}-5.22-gcc11-sincos.patch #787665
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +faudio +fontconfig +gecko gphoto2 gsm gssapi gstreamer +jpeg kerberos +lcms ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap +png pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama +xml"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -129,7 +130,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -195,32 +197,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -316,6 +304,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
@@ -306,7 +306,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.9.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}"/${PN}-6.6-glibc2.34-libresolv.patch
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.0-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.0-r2.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.0-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.0-r2.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.0.ebuild
@@ -297,7 +297,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.0.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -186,32 +188,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -307,6 +295,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.1.ebuild
@@ -297,7 +297,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -186,32 +188,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -307,6 +295,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.2.ebuild
@@ -297,7 +297,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.2.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -121,7 +122,8 @@ DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	virtual/yacc
 	X? ( x11-base/xorg-proto )
-	xinerama? ( x11-base/xorg-proto )"
+	xinerama? ( x11-base/xorg-proto )
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 # These use a non-standard "Wine" category, which is provided by
 # /etc/xdg/applications-merged/wine.menu
@@ -186,32 +188,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usex abi_x86_64 x86_64${mingw} '') $(usex abi_x86_32 i686${mingw} ''); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -307,6 +295,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${EPREFIX}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.3-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.3-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.3-r1.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.4-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.4-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.4-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.4-r1.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.5-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.5-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.5-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.5-r1.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.6-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.6-r1.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.6-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.6-r1.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.7.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vkd3d vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )
@@ -49,7 +50,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -187,32 +189,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -308,6 +296,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-7.7.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.7.ebuild
@@ -298,7 +298,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.8.ebuild
@@ -296,7 +296,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-7.8.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.8.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )" # osmesa-opengl #286560 # X-truetype #551124
@@ -48,7 +49,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -185,32 +187,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -306,6 +294,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -296,7 +296,11 @@ src_configure() {
 	if use mingw; then
 		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
 
-		export CROSSCFLAGS="${CFLAGS}"
+		# use *FLAGS for mingw, but strip unsupported (e.g. --hash-style=gnu)
+		local mingwcc=${CROSSCC:-$(usex x86 i686 x86_64)-w64-mingw32-gcc}
+		: "${CROSSCFLAGS:=$(CC=${mingwcc} test-flags-CC ${CFLAGS:--O2})}"
+		: "${CROSSLDFLAGS:=$(CC=${mingwcc} test-flags-CCLD ${LDFLAGS})}"
+		export CROSS{C,LD}FLAGS
 	fi
 
 	multilib-minimal_src_configure

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -35,9 +35,10 @@ SRC_URI="${SRC_URI}
 
 LICENSE="LGPL-2.1"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 +alsa capi cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
+IUSE="+abi_x86_32 +abi_x86_64 +alsa capi crossdev-mingw cups custom-cflags dos +fontconfig +gecko gphoto2 gssapi gstreamer kerberos ldap mingw +mono mp3 netapi nls odbc openal opencl +opengl osmesa oss +perl pcap pulseaudio +realtime +run-exes samba scanner sdl selinux +ssl test +threads +truetype udev +udisks +unwind usb v4l vulkan +X +xcomposite xinerama"
 REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )
 	X? ( truetype )
+	crossdev-mingw? ( mingw )
 	elibc_glibc? ( threads )
 	osmesa? ( opengl )
 	test? ( abi_x86_32 )" # osmesa-opengl #286560 # X-truetype #551124
@@ -48,7 +49,8 @@ RESTRICT="test"
 
 BDEPEND="sys-devel/flex
 	virtual/yacc
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	!crossdev-mingw? ( dev-util/mingw64-toolchain[${MULTILIB_USEDEP}] )"
 
 COMMON_DEPEND="
 	X? (
@@ -185,32 +187,18 @@ pkg_pretend() {
 		fi
 	fi
 
-	if use mingw && use abi_x86_32 && ! has_version "cross-i686-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-i686-w64-mingw32' compiler and its runtime for 32-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target i686-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
-	fi
-
-	if use mingw && use abi_x86_64 && ! has_version "cross-x86_64-w64-mingw32/gcc"; then
-		eerror
-		eerror "USE=\"mingw\" is currently experimental, and requires the"
-		eerror "'cross-x86_64-w64-mingw32' compiler and its runtime for 64-bit builds."
-		eerror
-		eerror "These can be installed by using 'sys-devel/crossdev':"
-		eerror
-		eerror "crossdev --target x86_64-w64-mingw32"
-		eerror
-		eerror "For more information on setting up MinGW, see: https://wiki.gentoo.org/wiki/Mingw"
-		eerror
-		die "MinGW build was enabled, but no compiler to support it was found."
+	if use crossdev-mingw && [[ ! -v MINGW_BYPASS ]]; then
+		local mingw=-w64-mingw32
+		for mingw in $(usev abi_x86_64 x86_64${mingw}) $(usev abi_x86_32 i686${mingw}); do
+			type -P ${mingw}-gcc && continue
+			eerror "With USE=crossdev-mingw, you must prepare the MinGW toolchain"
+			eerror "yourself by installing sys-devel/crossdev then running:"
+			eerror
+			eerror "    crossdev --target ${mingw}"
+			eerror
+			eerror "For more information, please see: https://wiki.gentoo.org/wiki/Mingw"
+			die "USE=crossdev-mingw is enabled, but ${mingw}-gcc was not found"
+		done
 	fi
 }
 
@@ -306,6 +294,8 @@ src_configure() {
 	export LDCONFIG=/bin/true
 	use custom-cflags || strip-flags
 	if use mingw; then
+		use crossdev-mingw || PATH=${BROOT}/usr/lib/mingw64-toolchain/bin:${PATH}
+
 		export CROSSCFLAGS="${CFLAGS}"
 	fi
 


### PR DESCRIPTION
Given crossdev tend to give users trouble (esp if need pthreads requiring a 3rd stage), mingw64-toolchain was added to build dxvk, vkd3d-proton, and wine[mingw] (optionally) without crossdev. It's a normal dependency, users have nothing special to do.

This PR copies dxvk/vkd3d-proton's style to enable support by default while still allowing crossdev for users that really want it. Uses bit different checks and a bypass method for users that do custom things (e.g. llvm-mingw).

ebuilds were changed with a script (incl. eapi-specific quirks), so if anything need changing I can regenerate all this easily.

Ran into gcc11 and glibc2.34 issues while trying older wines, included fixes -- then all versions having mingw in IUSE built from 5.22-r1 to 9999 for me.

Unsure how wine project would rather handle for stable ebuilds but, given the alternative was crossdev, straight-to sounds okay to me (mingw64-toolchain was stabled to allow this).

fwiw seen [some user interest](https://www.reddit.com/r/Gentoo/comments/uoilwp/yeah_the_nvidia_news_is_great_but_did_you_see/) since added these packages and could inform can drop the bad hacks :eyes: